### PR TITLE
Add clearSpecificAppNotifications method

### DIFF
--- a/android/src/main/java/com/wescj/eraser/EraserPlugin.java
+++ b/android/src/main/java/com/wescj/eraser/EraserPlugin.java
@@ -44,6 +44,17 @@ public class EraserPlugin implements FlutterPlugin, MethodCallHandler {
         }
       }
       result.success(null);
+    } else if("clearSpecificAppNotifications".equals(call.method)) {
+      String channelId = call.argument("channelId");
+      NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+      StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
+      for (StatusBarNotification notification : notifications) {
+        String notificationChannelId = notification.getNotification().getChannelId();
+        if(notificationChannelId.equals(channelId)){
+          notificationManager.cancel(notification.getId());
+        }
+      }
+      result.success(null);
     } else {
       result.notImplemented();
     }

--- a/ios/Classes/SwiftEraserPlugin.swift
+++ b/ios/Classes/SwiftEraserPlugin.swift
@@ -21,6 +21,33 @@ public class SwiftEraserPlugin: NSObject, FlutterPlugin {
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [tag])
         }
         result(nil)
+    } else if(call.method == "clearSpecificAppNotifications") {
+        if #available(iOS 10.0, *) {
+            let args = call.arguments as! Dictionary<String, String>
+            let dataKey = args["dataKey"]! as String
+            let dataValue = args["dataValue"]! as String
+            let center = UNUserNotificationCenter.current()
+            
+            center.getDeliveredNotifications { notifications in
+                    let notificationsToRemove = notifications.filter { notification in
+                        if let userInfo = notification.request.content.userInfo as? [String: Any],
+                           let type = userInfo[dataKey] as? String,
+                           type == dataValue {
+                            return true
+                        }
+                        return false
+                    }
+
+                    if !notificationsToRemove.isEmpty {
+                        let identifiersToRemove = notificationsToRemove.map { $0.request.identifier }
+                        center.removeDeliveredNotifications(withIdentifiers: identifiersToRemove)
+                        print("Removed notifications with \(dataKey) matching tag: \(dataValue)")
+                    } else {
+                        print("No notifications found with \(dataKey) matching tag: \(dataValue)")
+                    }
+                }
+        }
+        result(nil)
     } else if(call.method == "resetBadgeCountAndRemoveNotificationsFromCenter") {
         UIApplication.shared.applicationIconBadgeNumber = 0
         if #available(iOS 10.0, *) {

--- a/lib/eraser.dart
+++ b/lib/eraser.dart
@@ -1,9 +1,10 @@
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
 
 class Eraser {
-  static const MethodChannel _channel = const MethodChannel('eraser');
+  static const MethodChannel _channel = MethodChannel('eraser');
 
   /// Clears all push notifications that have been received by your Flutter app.
   ///
@@ -15,8 +16,10 @@ class Eraser {
     try {
       await _channel.invokeMethod('clearAllAppNotifications');
     } on PlatformException catch (e) {
-      print(
-          'Failed to clear all app notifications for following reason: ${e.message}');
+      log(
+        'Failed to clear all app notifications for following reason: ${e.message}',
+        name: 'Eraser',
+      );
     }
   }
 
@@ -32,8 +35,34 @@ class Eraser {
         'tag': tag,
       });
     } on PlatformException catch (e) {
-      print(
-          'Failed to clear app notifications for tag ($tag) for following reason: ${e.message}');
+      log(
+        'Failed to clear app notifications for tag ($tag) for following reason: ${e.message}',
+        name: 'Eraser',
+      );
+    }
+  }
+
+  /// Clears all push notifications that have been received by your Flutter app
+  /// with specific conditions. On iOS, all notifications that match the
+  /// specified [dataKey] and [dataValue] will be cleared. On Android, all
+  /// notifications that have the specified [channelId] will be cleared.
+  static Future<void> clearSpecificAppNotifications({
+    required String dataKey,
+    required String dataValue,
+    required String channelId,
+  }) async {
+    try {
+      await _channel
+          .invokeMethod('clearSpecificAppNotifications', <String, dynamic>{
+        'dataKey': dataKey, // e.g: 'NotificationType'
+        'dataValue': dataValue, // e.g: 'new_chat_message'
+        'channelId': channelId, // e.g: '1001'
+      });
+    } on PlatformException catch (e) {
+      log(
+        'Failed to clear specific app notifications for following reason: ${e.message}',
+        name: 'Eraser',
+      );
     }
   }
 
@@ -47,7 +76,10 @@ class Eraser {
         await _channel
             .invokeMethod('resetBadgeCountAndRemoveNotificationsFromCenter');
       } on PlatformException catch (e) {
-        print('Failed to reset badge count for following reason: ${e.message}');
+        log(
+          'Failed to reset badge count for following reason: ${e.message}',
+          name: 'Eraser',
+        );
       }
     }
   }
@@ -62,7 +94,10 @@ class Eraser {
         await _channel
             .invokeMethod('resetBadgeCountButKeepNotificationsInCenter');
       } on PlatformException catch (e) {
-        print('Failed to reset badge count for following reason: ${e.message}');
+        log(
+          'Failed to reset badge count for following reason: ${e.message}',
+          name: 'Eraser',
+        );
       }
     }
   }


### PR DESCRIPTION
The `clearSpecificAppNotifications` allows clearing push notifications with specific conditions. On iOS, all notifications that match the specified `dataKey` and `dataValue` will be cleared. On Android, all notifications that have the specified `channelId` will be cleared.